### PR TITLE
Add Integration test and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+
+script: mvn clean package archetype:integration-test

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Generating a format plugin is as easy as running the following:
       -DpluginClass=Foo                                 \
       -Dversion=0.0.1
 
+Repeated for the "newline" challenged:
+
+    mvn archetype:generate -DarchetypeArtifactId=nexus-format-archetype -DarchetypeGroupId=org.sonatype.nexus.archetype -DarchetypeVersion=1.0-SNAPSHOT -DgroupId=org.sonatype.nexus.repository -DartifactId=nexus-repository-foo -DpluginFormat=foo -DpluginClass=Foo -Dversion=0.0.1
+    
 It is recommended to keep the naming of the following parameters consistent with the plugin you wish to develop:
 
 **pluginFormat** = _A name with no whitespace that best describes the format_ (e.g. raw, yum, npm etc.)

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -25,7 +25,7 @@
   <artifactId>${artifactId}</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>
   <version>${version}</version>
-  <inceptionYear>2018</inceptionYear>
+  <inceptionYear>2019</inceptionYear>
   <packaging>bundle</packaging>
 
   <dependencies>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -54,12 +54,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.spockframework</groupId>
-      <artifactId>spock-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.sonatype.nexus</groupId>
       <artifactId>nexus-rapture</artifactId>
       <scope>provided</scope>

--- a/src/test/resources/projects/it1/archetype.properties
+++ b/src/test/resources/projects/it1/archetype.properties
@@ -1,0 +1,6 @@
+groupId=org.sonatype.nexus.repository
+package=org.sonatype.nexus.repository
+artifactId=nexus-repository-foo
+pluginFormat=foo
+pluginClass=Foo
+version=0.0.1

--- a/src/test/resources/projects/it1/goal.txt
+++ b/src/test/resources/projects/it1/goal.txt
@@ -1,0 +1,1 @@
+clean package

--- a/src/test/resources/projects/it1/reference/pom.xml
+++ b/src/test/resources/projects/it1/reference/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Sonatype Nexus (TM) Open Source Version
+    Copyright (c) 2018-present Sonatype, Inc.
+    All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+
+    This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+    which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+
+    Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+    of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+    Eclipse Foundation. All other trademarks are the property of their respective owners.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.sonatype.nexus.plugins</groupId>
+    <artifactId>nexus-plugins</artifactId>
+    <version>3.14.0-04</version>
+  </parent>
+  <groupId>org.sonatype.nexus.repository</groupId>
+  <artifactId>nexus-repository-foo</artifactId>
+  <name>${project.groupId}:${project.artifactId}</name>
+  <version>0.0.1</version>
+  <inceptionYear>2019</inceptionYear>
+  <packaging>bundle</packaging>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-plugin-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-repository</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.sonatype.goodies</groupId>
+      <artifactId>goodies-testsupport</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-rapture</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.nexus.buildsupport</groupId>
+        <artifactId>extjs-maven-plugin</artifactId>
+        <configuration>
+          <namespace>NX.foo</namespace>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>yuicompressor-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.karaf.tooling</groupId>
+        <artifactId>karaf-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.20</version>
+      </plugin>
+
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/FooFormat.java
+++ b/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/FooFormat.java
@@ -1,0 +1,33 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.foo.internal;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.nexus.repository.Format;
+
+/**
+ * Foo repository format.
+ */
+@Named(FooFormat.NAME)
+@Singleton
+public class FooFormat
+    extends Format
+{
+  public static final String NAME = "foo";
+
+  public FooFormat() {
+    super(NAME);
+  }
+}

--- a/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/FooRecipeSupport.groovy
+++ b/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/FooRecipeSupport.groovy
@@ -1,0 +1,108 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.foo.internal
+
+import javax.inject.Inject
+import javax.inject.Provider
+
+import org.sonatype.nexus.repository.foo.internal.security.FooSecurityFacet
+
+import org.sonatype.nexus.repository.Format
+import org.sonatype.nexus.repository.RecipeSupport
+import org.sonatype.nexus.repository.Type
+import org.sonatype.nexus.repository.attributes.AttributesFacet
+import org.sonatype.nexus.repository.cache.NegativeCacheFacet
+import org.sonatype.nexus.repository.cache.NegativeCacheHandler
+import org.sonatype.nexus.repository.http.PartialFetchHandler
+import org.sonatype.nexus.repository.httpclient.HttpClientFacet
+import org.sonatype.nexus.repository.purge.PurgeUnusedFacet
+import org.sonatype.nexus.repository.search.SearchFacet
+import org.sonatype.nexus.repository.security.SecurityHandler
+import org.sonatype.nexus.repository.storage.DefaultComponentMaintenanceImpl
+import org.sonatype.nexus.repository.storage.StorageFacet
+import org.sonatype.nexus.repository.storage.UnitOfWorkHandler
+import org.sonatype.nexus.repository.view.ConfigurableViewFacet
+import org.sonatype.nexus.repository.view.handlers.BrowseUnsupportedHandler
+import org.sonatype.nexus.repository.view.handlers.ConditionalRequestHandler
+import org.sonatype.nexus.repository.view.handlers.ContentHeadersHandler
+import org.sonatype.nexus.repository.view.handlers.ExceptionHandler
+import org.sonatype.nexus.repository.view.handlers.HandlerContributor
+import org.sonatype.nexus.repository.view.handlers.TimingHandler
+
+/**
+ * Support for Foo recipes.
+ */
+abstract class FooRecipeSupport
+    extends RecipeSupport
+{
+  @Inject
+  Provider<FooSecurityFacet> securityFacet
+
+  @Inject
+  Provider<ConfigurableViewFacet> viewFacet
+
+  @Inject
+  Provider<StorageFacet> storageFacet
+
+  @Inject
+  Provider<SearchFacet> searchFacet
+
+  @Inject
+  Provider<AttributesFacet> attributesFacet
+
+  @Inject
+  ExceptionHandler exceptionHandler
+
+  @Inject
+  TimingHandler timingHandler
+
+  @Inject
+  SecurityHandler securityHandler
+
+  @Inject
+  PartialFetchHandler partialFetchHandler
+
+  @Inject
+  ConditionalRequestHandler conditionalRequestHandler
+
+  @Inject
+  ContentHeadersHandler contentHeadersHandler
+
+  @Inject
+  UnitOfWorkHandler unitOfWorkHandler
+
+  @Inject
+  BrowseUnsupportedHandler browseUnsupportedHandler
+
+  @Inject
+  HandlerContributor handlerContributor
+
+  @Inject
+  Provider<DefaultComponentMaintenanceImpl> componentMaintenanceFacet
+
+  @Inject
+  Provider<HttpClientFacet> httpClientFacet
+
+  @Inject
+  Provider<PurgeUnusedFacet> purgeUnusedFacet
+
+  @Inject
+  Provider<NegativeCacheFacet> negativeCacheFacet
+
+  @Inject
+  NegativeCacheHandler negativeCacheHandler
+
+  protected FooRecipeSupport(final Type type, final Format format) {
+    super(type, format)
+  }
+}

--- a/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/security/FooFormatSecurityContributor.java
+++ b/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/security/FooFormatSecurityContributor.java
@@ -1,0 +1,35 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.foo.internal.security;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.nexus.repository.Format;
+import org.sonatype.nexus.repository.foo.internal.FooFormat;
+import org.sonatype.nexus.repository.security.RepositoryFormatSecurityContributor;
+
+/**
+ * Foo format security resource.
+ */
+@Named
+@Singleton
+public class FooFormatSecurityContributor
+    extends RepositoryFormatSecurityContributor
+{
+  @Inject
+  public FooFormatSecurityContributor(@Named(FooFormat.NAME) final Format format) {
+    super(format);
+  }
+}

--- a/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/security/FooFormatSecurityContributor.java
+++ b/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/security/FooFormatSecurityContributor.java
@@ -16,8 +16,9 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.sonatype.nexus.repository.Format;
 import org.sonatype.nexus.repository.foo.internal.FooFormat;
+
+import org.sonatype.nexus.repository.Format;
 import org.sonatype.nexus.repository.security.RepositoryFormatSecurityContributor;
 
 /**

--- a/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/security/FooSecurityFacet.java
+++ b/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/security/FooSecurityFacet.java
@@ -1,0 +1,42 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.foo.internal.security;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.sonatype.nexus.repository.config.Configuration;
+import org.sonatype.nexus.repository.security.ContentPermissionChecker;
+import org.sonatype.nexus.repository.security.SecurityFacetSupport;
+import org.sonatype.nexus.repository.security.VariableResolverAdapter;
+
+/**
+ * Foo format security facet.
+ */
+@Named
+public class FooSecurityFacet
+    extends SecurityFacetSupport
+{
+  @Inject
+  public FooSecurityFacet(final FooFormatSecurityContributor securityResource,
+                            @Named("simple") final VariableResolverAdapter variableResolverAdapter,
+                            final ContentPermissionChecker contentPermissionChecker)
+  {
+    super(securityResource, variableResolverAdapter, contentPermissionChecker);
+  }
+
+  @Override
+  protected void doValidate(final Configuration configuration) throws Exception {
+    super.doValidate(configuration);
+  }
+}

--- a/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/ui/UiPluginDescriptorImpl.java
+++ b/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/ui/UiPluginDescriptorImpl.java
@@ -1,0 +1,32 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.foo.internal.ui;
+
+import javax.annotation.Priority;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.nexus.rapture.UiPluginDescriptorSupport;
+
+@Named
+@Singleton
+@Priority(Integer.MAX_VALUE - 200)
+public class UiPluginDescriptorImpl
+    extends UiPluginDescriptorSupport
+{
+  public UiPluginDescriptorImpl() {
+    super("nexus-repository-foo");
+    setNamespace("NX.foo");
+    setConfigClassName("NX.foo.app.PluginConfig");
+  }
+}

--- a/src/test/resources/projects/it1/reference/src/main/resources/static/rapture/NX/foo/app/PluginConfig.js
+++ b/src/test/resources/projects/it1/reference/src/main/resources/static/rapture/NX/foo/app/PluginConfig.js
@@ -1,0 +1,20 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+Ext.define('NX.foo.app.PluginConfig', {
+  '@aggregate_priority': 100,
+
+  requires: [
+    'NX.foo.app.PluginStrings',
+    'NX.foo.util.FooRepositoryUrls'
+  ]
+});

--- a/src/test/resources/projects/it1/reference/src/main/resources/static/rapture/NX/foo/app/PluginStrings.js
+++ b/src/test/resources/projects/it1/reference/src/main/resources/static/rapture/NX/foo/app/PluginStrings.js
@@ -1,0 +1,36 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+
+/*global Ext, NX*/
+
+/**
+ * Foo plugin strings.
+ */
+Ext.define('NX.foo.app.PluginStrings', {
+  '@aggregate_priority': 90,
+
+  singleton: true,
+  requires: [
+    'NX.I18n'
+  ],
+
+  keys: {
+    Repository_Facet_FooFacet_Title: 'Foo Settings',
+    SearchFoo_Group: 'Foo Repositories',
+    SearchFoo_License_FieldLabel: 'License',
+    SearchFoo_Text: 'Foo',
+    SearchFoo_Description: 'Search for components in Foo repositories',
+  }
+}, function(self) {
+  NX.I18n.register(self);
+});

--- a/src/test/resources/projects/it1/reference/src/main/resources/static/rapture/NX/foo/util/FooRepositoryUrls.js
+++ b/src/test/resources/projects/it1/reference/src/main/resources/static/rapture/NX/foo/util/FooRepositoryUrls.js
@@ -1,0 +1,26 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+Ext.define('NX.foo.util.FooRepositoryUrls', {
+  '@aggregate_priority': 90,
+
+  singleton: true,
+  requires: [
+    'NX.coreui.util.RepositoryUrls',
+    'NX.util.Url'
+  ]
+}, function(self) {
+	NX.coreui.util.RepositoryUrls.addRepositoryUrlStrategy('foo', function (assetModel) {
+      var repositoryName = assetModel.get('repositoryName'), assetName = assetModel.get('name');
+      return NX.util.Url.asLink(NX.util.Url.baseUrl + '/repository/' + repositoryName + '/' + assetName, assetName);
+    });
+});

--- a/src/test/resources/projects/it1/reference/src/main/resources/static/rapture/resources/nexus-repository-foo-debug.css
+++ b/src/test/resources/projects/it1/reference/src/main/resources/static/rapture/resources/nexus-repository-foo-debug.css
@@ -1,0 +1,13 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+/* placeholder */

--- a/src/test/resources/projects/it1/reference/src/test/java/org/sonatype/nexus/repository/foo/internal/FooFormatTest.java
+++ b/src/test/resources/projects/it1/reference/src/test/java/org/sonatype/nexus/repository/foo/internal/FooFormatTest.java
@@ -1,0 +1,31 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.foo.internal;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class FooFormatTest
+{
+  private FooFormat underTest;
+
+  @Test
+  public void checkFormatNameIsCorrect() {
+    underTest = new FooFormat();
+
+    assertThat(underTest.getValue(), is(equalTo("foo")));
+  }
+}

--- a/src/test/resources/projects/it1/reference/src/test/java/org/sonatype/nexus/repository/foo/internal/security/FooSecurityFacetTest.java
+++ b/src/test/resources/projects/it1/reference/src/test/java/org/sonatype/nexus/repository/foo/internal/security/FooSecurityFacetTest.java
@@ -1,0 +1,90 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.foo.internal.security;
+
+import org.sonatype.goodies.testsupport.TestSupport;
+import org.sonatype.nexus.repository.Format;
+import org.sonatype.nexus.repository.Repository;
+import org.sonatype.nexus.repository.http.HttpMethods;
+import org.sonatype.nexus.repository.security.ContentPermissionChecker;
+import org.sonatype.nexus.repository.security.VariableResolverAdapter;
+import org.sonatype.nexus.repository.view.Request;
+
+import org.apache.shiro.authz.AuthorizationException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.sonatype.nexus.security.BreadActions.READ;
+
+public class FooSecurityFacetTest
+    extends TestSupport
+{
+  @Mock
+  Request request;
+
+  @Mock
+  Repository repository;
+
+  @Mock
+  ContentPermissionChecker contentPermissionChecker;
+
+  @Mock
+  VariableResolverAdapter variableResolverAdapter;
+
+  @Mock
+  FooFormatSecurityContributor securityContributor;
+
+  FooSecurityFacet fooSecurityFacet;
+
+  @Before
+  public void setupConfig() throws Exception {
+    when(request.getPath()).thenReturn("/some/path.txt");
+    when(request.getAction()).thenReturn(HttpMethods.GET);
+
+    when(repository.getFormat()).thenReturn(new Format("foo") { });
+    when(repository.getName()).thenReturn("FooSecurityFacetTest");
+
+    fooSecurityFacet = new FooSecurityFacet(securityContributor,
+        variableResolverAdapter, contentPermissionChecker);
+
+    fooSecurityFacet.attach(repository);
+  }
+
+  @Test
+  public void testEnsurePermitted_permitted() throws Exception {
+    when(contentPermissionChecker.isPermitted(eq("FooSecurityFacetTest"), eq("foo"), eq(READ), any()))
+        .thenReturn(true);
+    fooSecurityFacet.ensurePermitted(request);
+  }
+
+  @Test
+  public void testEnsurePermitted_notPermitted() throws Exception {
+    when(contentPermissionChecker.isPermitted(eq("FooSecurityFacetTest"), eq("foo"), eq(READ), any()))
+        .thenReturn(false);
+    try {
+      fooSecurityFacet.ensurePermitted(request);
+      fail("AuthorizationException should have been thrown");
+    }
+    catch (AuthorizationException e) {
+      //expected
+    }
+
+    verify(contentPermissionChecker).isPermitted(eq("FooSecurityFacetTest"), eq("foo"), eq(READ), any());
+  }
+}


### PR DESCRIPTION
adds an integration test and associated "reference" files that must match the output generated by the integration test.

Also has an initial Travis CI config file to ensure shiny new tests are run.

remove 'spock' dependency