### PR TITLE
new optional parameter for NexusPluginsVersion. fixes #5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 if: tag IS blank
 
 language: java
+jdk:
+  - openjdk8
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 
 ## export GPG details
 before_install:
+  - export GPG_TTY=$(tty)
   - echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import
   - echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,8 @@ cache:
 
 ## export GPG details
 before_install:
-  - export GPG_TTY=$(tty)
-  - echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import
-  - echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust
+  #- echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import
+  #- echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust
 
 script:
   - mvn clean package archetype:integration-test --settings .maven.xml --batch-mode  -U deploy -Prelease

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ cache:
 
 ## export GPG details
 before_install:
-  #- echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import
-  #- echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust
+  - echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import
+  - echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust
 
 script:
   - mvn clean package archetype:integration-test --settings .maven.xml --batch-mode  -U deploy -Prelease

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Coordinates of the archetype:
 
 **archetypeGroupId** = _Must be:_ org.sonatype.nexus.archetypes
 
-**archetypeVersion** = The version of this archetype (e.g. 1.0-SNAPSHOT)
+**archetypeVersion** = _The version of this archetype_ (e.g. 1.0-SNAPSHOT)
 
 It is recommended to keep the naming of the following parameters consistent with the plugin you wish to develop:
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Generating a format plugin is as easy as running the following:
       -DarchetypeArtifactId=nexus-format-archetype      \
       -DarchetypeGroupId=org.sonatype.nexus.archetypes  \
       -DarchetypeVersion=1.0-SNAPSHOT                   \
+      -DnexusPluginsVersion=3.18.0-01                   \
       -DgroupId=org.sonatype.nexus.repository           \
       -DartifactId=nexus-repository-foo                 \
       -DpluginFormat=foo                                \
@@ -35,15 +36,19 @@ Generating a format plugin is as easy as running the following:
 
 Repeated for the "newline" challenged:
 
-    mvn archetype:generate -DarchetypeArtifactId=nexus-format-archetype -DarchetypeGroupId=org.sonatype.nexus.archetypes -DarchetypeVersion=1.0-SNAPSHOT -DgroupId=org.sonatype.nexus.repository -DartifactId=nexus-repository-foo -DpluginFormat=foo -DpluginClass=Foo -Dversion=0.0.1
+    mvn archetype:generate -DarchetypeArtifactId=nexus-format-archetype -DarchetypeGroupId=org.sonatype.nexus.archetypes -DarchetypeVersion=1.0-SNAPSHOT -DnexusPluginsVersion=3.18.0-01 -DgroupId=org.sonatype.nexus.repository -DartifactId=nexus-repository-foo -DpluginFormat=foo -DpluginClass=Foo -Dversion=0.0.1
     
+Optional parameters can be omitted. A shorter example using default parameter values:
+
+    mvn archetype:generate -DarchetypeArtifactId=nexus-format-archetype -DarchetypeGroupId=org.sonatype.nexus.archetypes -DarchetypeVersion=1.0-SNAPSHOT -DpluginFormat=foo -DpluginClass=Foo
+
 It is recommended to keep the naming of the following parameters consistent with the plugin you wish to develop:
 
 **pluginFormat** = _A name with no whitespace that best describes the format_ (e.g. raw, yum, npm etc.)
 
 **pluginClass** = _The class name that will be used to generate the plugin boilerplate code_ (e.g. Raw, Yum, Npm etc.)
 
-**version** = _The version of the format to be developed_      
+**version** = _The version of the format to be developed_ (default: 0.0.1-SNAPSHOT)     
 
 ## How to contribute to this archetype
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Generating a format plugin is as easy as running the following:
       -DarchetypeArtifactId=nexus-format-archetype      \
       -DarchetypeGroupId=org.sonatype.nexus.archetypes  \
       -DarchetypeVersion=1.0-SNAPSHOT                   \
-      -DnexusPluginsVersion=3.18.0-01                   \
       -DgroupId=org.sonatype.nexus.repository           \
       -DartifactId=nexus-repository-foo                 \
       -DpluginFormat=foo                                \
@@ -36,17 +35,36 @@ Generating a format plugin is as easy as running the following:
 
 Repeated for the "newline" challenged:
 
-    mvn archetype:generate -DarchetypeArtifactId=nexus-format-archetype -DarchetypeGroupId=org.sonatype.nexus.archetypes -DarchetypeVersion=1.0-SNAPSHOT -DnexusPluginsVersion=3.18.0-01 -DgroupId=org.sonatype.nexus.repository -DartifactId=nexus-repository-foo -DpluginFormat=foo -DpluginClass=Foo -Dversion=0.0.1
+    mvn archetype:generate -DarchetypeArtifactId=nexus-format-archetype -DarchetypeGroupId=org.sonatype.nexus.archetypes -DarchetypeVersion=1.0-SNAPSHOT -DgroupId=org.sonatype.nexus.repository -DartifactId=nexus-repository-foo -DpluginFormat=foo -DpluginClass=Foo -Dversion=0.0.1
     
 Optional parameters can be omitted. A shorter example using default parameter values:
 
     mvn archetype:generate -DarchetypeArtifactId=nexus-format-archetype -DarchetypeGroupId=org.sonatype.nexus.archetypes -DarchetypeVersion=1.0-SNAPSHOT -DpluginFormat=foo -DpluginClass=Foo
+
+#### Required parameters:
+
+Coordinates of the archetype:
+
+**archetypeArtifactId** = _Must be:_ nexus-format-archetype
+
+**archetypeGroupId** = _Must be:_ org.sonatype.nexus.archetypes
+
+**archetypeVersion** = The version of this archetype (e.g. 1.0-SNAPSHOT)
 
 It is recommended to keep the naming of the following parameters consistent with the plugin you wish to develop:
 
 **pluginFormat** = _A name with no whitespace that best describes the format_ (e.g. raw, yum, npm etc.)
 
 **pluginClass** = _The class name that will be used to generate the plugin boilerplate code_ (e.g. Raw, Yum, Npm etc.)
+
+#### Optional parameters:
+
+**nexusPluginsVersion** = _The version of Nexus to use in the format to be developed_ 
+(default: Declared as a property in the archetype [pom.xml ~line 62-> defaultNexusPluginsVersion](./pom.xml#L62]))
+
+**artifactId** = _The artifactId of the format to be developed_ (default: nexus-repository-${pluginFormat})
+
+**groupId** = _The groupId (and package) of the format to be developed_ (default: org.sonatype.nexus.repository)
 
 **version** = _The version of the format to be developed_ (default: 0.0.1-SNAPSHOT)     
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,41 @@
     </repository>
   </distributionManagement>
 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <defaultNexusPluginsVersion>3.18.0-01</defaultNexusPluginsVersion>
+  </properties>
+
+  <build>
+    <filters>
+      <!--
+      Filter ensures the generated pom groupId, artifactId, and version get intended values, instead of parent values.
+      -->
+      <filter>src/test/my-filter-values.properties</filter>
+    </filters>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
+    <plugins>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <escapeString>\</escapeString>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>release</id>

--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -3,9 +3,22 @@
 name="nexus-format-archetype">
 
   <requiredProperties>
+    <requiredProperty key="nexusPluginsVersion">
+      <defaultValue>${defaultNexusPluginsVersion}</defaultValue>
+    </requiredProperty>
+    <requiredProperty key="groupId">
+      <defaultValue>org.sonatype.nexus.repository</defaultValue>
+    </requiredProperty>
     <requiredProperty key="pluginFormat"></requiredProperty>
-    <requiredProperty key="pluginClass"></requiredProperty>
-    <requiredProperty key="version"></requiredProperty>
+    <requiredProperty key="artifactId">
+      <defaultValue>nexus-repository-${pluginFormat}</defaultValue>
+    </requiredProperty>
+    <requiredProperty key="pluginClass">
+      <!-- @todo Default to capitalized version of ${pluginFormat} -->
+    </requiredProperty>
+    <requiredProperty key="version">
+      <defaultValue>0.0.1-SNAPSHOT</defaultValue>
+    </requiredProperty>
   </requiredProperties>
 
   <fileSets>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -19,12 +19,12 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-plugins</artifactId>
-    <version>3.15.0-01</version>
+    <version>${nexusPluginsVersion}</version>
   </parent>
-  <groupId>${groupId}</groupId>
-  <artifactId>${artifactId}</artifactId>
-  <name>${project.groupId}:${project.artifactId}</name>
-  <version>${version}</version>
+  <groupId>\${groupId}</groupId>
+  <artifactId>\${artifactId}</artifactId>
+  <name>\${project.groupId}:\${project.artifactId}</name>
+  <version>\${version}</version>
   <inceptionYear>2019</inceptionYear>
   <packaging>bundle</packaging>
 

--- a/src/test/my-filter-values.properties
+++ b/src/test/my-filter-values.properties
@@ -1,0 +1,3 @@
+groupId=org.sonatype.nexus.repository
+artifactId=nexus-repository-foo
+version=0.0.1

--- a/src/test/resources/projects/it1/archetype.properties
+++ b/src/test/resources/projects/it1/archetype.properties
@@ -1,3 +1,4 @@
+nexusPluginsVersion=${defaultNexusPluginsVersion}
 groupId=org.sonatype.nexus.repository
 package=org.sonatype.nexus.repository
 artifactId=nexus-repository-foo

--- a/src/test/resources/projects/it1/reference/pom.xml
+++ b/src/test/resources/projects/it1/reference/pom.xml
@@ -19,11 +19,11 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-plugins</artifactId>
-    <version>3.15.0-01</version>
+    <version>${defaultNexusPluginsVersion}</version>
   </parent>
   <groupId>org.sonatype.nexus.repository</groupId>
   <artifactId>nexus-repository-foo</artifactId>
-  <name>${project.groupId}:${project.artifactId}</name>
+  <name>\${project.groupId}:\${project.artifactId}</name>
   <version>0.0.1</version>
   <inceptionYear>2019</inceptionYear>
   <packaging>bundle</packaging>


### PR DESCRIPTION
This PR adds an optional parameter that can specify which version of Nexus Repository Manager to build against.

While I was in there, I also added some default values for some other parameters.