### PR TITLE
default InceptionYear to current year. mostly Fixes #6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,24 @@
           <escapeString>\</escapeString>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>timestamp-property</id>
+            <goals>
+              <goal>timestamp-property</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <name>current.year</name>
+              <pattern>yyyy</pattern>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -25,7 +25,7 @@
   <artifactId>\${artifactId}</artifactId>
   <name>\${project.groupId}:\${project.artifactId}</name>
   <version>\${version}</version>
-  <inceptionYear>2019</inceptionYear>
+  <inceptionYear>${current.year}</inceptionYear>
   <packaging>bundle</packaging>
 
   <dependencies>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -2,7 +2,7 @@
 <!--
 
     Sonatype Nexus (TM) Open Source Version
-    Copyright (c) 2018-present Sonatype, Inc.
+    Copyright (c) ${current.year}-present Sonatype, Inc.
     All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
 
     This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,

--- a/src/main/resources/archetype-resources/src/main/java/__pluginFormat__/internal/__pluginClass__Format.java
+++ b/src/main/resources/archetype-resources/src/main/java/__pluginFormat__/internal/__pluginClass__Format.java
@@ -10,10 +10,12 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
-package $ import javax.inject.Named;
+package ${package}.${pluginFormat}.internal;
+
+import javax.inject.Named;
 import javax.inject.Singleton;
 
-{package}.${pluginFormat}.internal;
+import org.sonatype.nexus.repository.Format;
 
 /**
  * ${pluginClass} repository format.

--- a/src/main/resources/archetype-resources/src/main/java/__pluginFormat__/internal/__pluginClass__Format.java
+++ b/src/main/resources/archetype-resources/src/main/java/__pluginFormat__/internal/__pluginClass__Format.java
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
@@ -10,12 +10,10 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
-package ${package}.${pluginFormat}.internal;
-
-import javax.inject.Named;
+package $ import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.sonatype.nexus.repository.Format;
+{package}.${pluginFormat}.internal;
 
 /**
  * ${pluginClass} repository format.

--- a/src/main/resources/archetype-resources/src/main/java/__pluginFormat__/internal/__pluginClass__RecipeSupport.groovy
+++ b/src/main/resources/archetype-resources/src/main/java/__pluginFormat__/internal/__pluginClass__RecipeSupport.groovy
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,

--- a/src/main/resources/archetype-resources/src/main/java/__pluginFormat__/internal/security/__pluginClass__FormatSecurityContributor.java
+++ b/src/main/resources/archetype-resources/src/main/java/__pluginFormat__/internal/security/__pluginClass__FormatSecurityContributor.java
@@ -10,11 +10,16 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
-package $ import javax.inject.Named;
+package ${package}.${pluginFormat}.internal.security;
+
+import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 
-{package}.${pluginFormat}.internal.security;
-        {package}.${pluginFormat}.internal.${pluginClass}Format;
+import ${package}.${pluginFormat}.internal.${pluginClass}Format;
+
+import org.sonatype.nexus.repository.Format;
+import org.sonatype.nexus.repository.security.RepositoryFormatSecurityContributor;
 
 /**
  * ${pluginClass} format security resource.

--- a/src/main/resources/archetype-resources/src/main/java/__pluginFormat__/internal/security/__pluginClass__FormatSecurityContributor.java
+++ b/src/main/resources/archetype-resources/src/main/java/__pluginFormat__/internal/security/__pluginClass__FormatSecurityContributor.java
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
@@ -10,16 +10,11 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
-package ${package}.${pluginFormat}.internal.security;
-
-import javax.inject.Inject;
-import javax.inject.Named;
+package $ import javax.inject.Named;
 import javax.inject.Singleton;
 
-import ${package}.${pluginFormat}.internal.${pluginClass}Format;
-
-import org.sonatype.nexus.repository.Format;
-import org.sonatype.nexus.repository.security.RepositoryFormatSecurityContributor;
+{package}.${pluginFormat}.internal.security;
+        {package}.${pluginFormat}.internal.${pluginClass}Format;
 
 /**
  * ${pluginClass} format security resource.

--- a/src/main/resources/archetype-resources/src/main/java/__pluginFormat__/internal/security/__pluginClass__SecurityFacet.java
+++ b/src/main/resources/archetype-resources/src/main/java/__pluginFormat__/internal/security/__pluginClass__SecurityFacet.java
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
@@ -10,15 +10,9 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
-package ${package}.${pluginFormat}.internal.security;
+package $ import javax.inject.Named;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-
-import org.sonatype.nexus.repository.config.Configuration;
-import org.sonatype.nexus.repository.security.ContentPermissionChecker;
-import org.sonatype.nexus.repository.security.SecurityFacetSupport;
-import org.sonatype.nexus.repository.security.VariableResolverAdapter;
+{package}.${pluginFormat}.internal.security;
 
 /**
  * ${pluginClass} format security facet.

--- a/src/main/resources/archetype-resources/src/main/java/__pluginFormat__/internal/security/__pluginClass__SecurityFacet.java
+++ b/src/main/resources/archetype-resources/src/main/java/__pluginFormat__/internal/security/__pluginClass__SecurityFacet.java
@@ -10,9 +10,15 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
-package $ import javax.inject.Named;
+package ${package}.${pluginFormat}.internal.security;
 
-{package}.${pluginFormat}.internal.security;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.sonatype.nexus.repository.config.Configuration;
+import org.sonatype.nexus.repository.security.ContentPermissionChecker;
+import org.sonatype.nexus.repository.security.SecurityFacetSupport;
+import org.sonatype.nexus.repository.security.VariableResolverAdapter;
 
 /**
  * ${pluginClass} format security facet.

--- a/src/main/resources/archetype-resources/src/main/java/__pluginFormat__/internal/ui/UiPluginDescriptorImpl.java
+++ b/src/main/resources/archetype-resources/src/main/java/__pluginFormat__/internal/ui/UiPluginDescriptorImpl.java
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
@@ -10,13 +10,13 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
-package ${package}.${pluginFormat}.internal.ui;
+package $ import org.sonatype.nexus.rapture.UiPluginDescriptorSupport;
 
 import javax.annotation.Priority;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.sonatype.nexus.rapture.UiPluginDescriptorSupport;
+{package}.${pluginFormat}.internal.ui;
 
 @Named
 @Singleton

--- a/src/main/resources/archetype-resources/src/main/java/__pluginFormat__/internal/ui/UiPluginDescriptorImpl.java
+++ b/src/main/resources/archetype-resources/src/main/java/__pluginFormat__/internal/ui/UiPluginDescriptorImpl.java
@@ -10,13 +10,13 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
-package $ import org.sonatype.nexus.rapture.UiPluginDescriptorSupport;
+package ${package}.${pluginFormat}.internal.ui;
 
 import javax.annotation.Priority;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-{package}.${pluginFormat}.internal.ui;
+import org.sonatype.nexus.rapture.UiPluginDescriptorSupport;
 
 @Named
 @Singleton

--- a/src/main/resources/archetype-resources/src/main/resources/static/rapture/NX/__pluginFormat__/app/PluginConfig.js
+++ b/src/main/resources/archetype-resources/src/main/resources/static/rapture/NX/__pluginFormat__/app/PluginConfig.js
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,

--- a/src/main/resources/archetype-resources/src/main/resources/static/rapture/NX/__pluginFormat__/app/PluginStrings.js
+++ b/src/main/resources/archetype-resources/src/main/resources/static/rapture/NX/__pluginFormat__/app/PluginStrings.js
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,

--- a/src/main/resources/archetype-resources/src/main/resources/static/rapture/NX/__pluginFormat__/util/__pluginClass__RepositoryUrls.js
+++ b/src/main/resources/archetype-resources/src/main/resources/static/rapture/NX/__pluginFormat__/util/__pluginClass__RepositoryUrls.js
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,

--- a/src/main/resources/archetype-resources/src/main/resources/static/rapture/resources/__artifactId__-debug.css
+++ b/src/main/resources/archetype-resources/src/main/resources/static/rapture/resources/__artifactId__-debug.css
@@ -1,6 +1,6 @@
 /**
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,

--- a/src/main/resources/archetype-resources/src/test/java/__pluginFormat__/internal/__pluginClass__FormatTest.java
+++ b/src/main/resources/archetype-resources/src/test/java/__pluginFormat__/internal/__pluginClass__FormatTest.java
@@ -12,6 +12,12 @@
  */
 package ${package}.${pluginFormat}.internal;
 
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 public class ${pluginClass}FormatTest
 {
   private ${pluginClass}Format underTest;

--- a/src/main/resources/archetype-resources/src/test/java/__pluginFormat__/internal/__pluginClass__FormatTest.java
+++ b/src/main/resources/archetype-resources/src/test/java/__pluginFormat__/internal/__pluginClass__FormatTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
@@ -11,12 +11,6 @@
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
 package ${package}.${pluginFormat}.internal;
-
-import org.junit.Test;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ${pluginClass}FormatTest
 {

--- a/src/main/resources/archetype-resources/src/test/java/__pluginFormat__/internal/security/__pluginClass__SecurityFacetTest.java
+++ b/src/main/resources/archetype-resources/src/test/java/__pluginFormat__/internal/security/__pluginClass__SecurityFacetTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
@@ -11,26 +11,6 @@
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
 package ${package}.${pluginFormat}.internal.security;
-
-import org.sonatype.goodies.testsupport.TestSupport;
-import org.sonatype.nexus.repository.Format;
-import org.sonatype.nexus.repository.Repository;
-import org.sonatype.nexus.repository.http.HttpMethods;
-import org.sonatype.nexus.repository.security.ContentPermissionChecker;
-import org.sonatype.nexus.repository.security.VariableResolverAdapter;
-import org.sonatype.nexus.repository.view.Request;
-
-import org.apache.shiro.authz.AuthorizationException;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.sonatype.nexus.security.BreadActions.READ;
 
 public class ${pluginClass}SecurityFacetTest
     extends TestSupport

--- a/src/main/resources/archetype-resources/src/test/java/__pluginFormat__/internal/security/__pluginClass__SecurityFacetTest.java
+++ b/src/main/resources/archetype-resources/src/test/java/__pluginFormat__/internal/security/__pluginClass__SecurityFacetTest.java
@@ -12,6 +12,26 @@
  */
 package ${package}.${pluginFormat}.internal.security;
 
+import org.sonatype.goodies.testsupport.TestSupport;
+import org.sonatype.nexus.repository.Format;
+import org.sonatype.nexus.repository.Repository;
+import org.sonatype.nexus.repository.http.HttpMethods;
+import org.sonatype.nexus.repository.security.ContentPermissionChecker;
+import org.sonatype.nexus.repository.security.VariableResolverAdapter;
+import org.sonatype.nexus.repository.view.Request;
+
+import org.apache.shiro.authz.AuthorizationException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.sonatype.nexus.security.BreadActions.READ;
+
 public class ${pluginClass}SecurityFacetTest
     extends TestSupport
 {

--- a/src/test/resources/projects/it1/reference/pom.xml
+++ b/src/test/resources/projects/it1/reference/pom.xml
@@ -25,7 +25,7 @@
   <artifactId>nexus-repository-foo</artifactId>
   <name>\${project.groupId}:\${project.artifactId}</name>
   <version>0.0.1</version>
-  <inceptionYear>2019</inceptionYear>
+  <inceptionYear>${current.year}</inceptionYear>
   <packaging>bundle</packaging>
 
   <dependencies>

--- a/src/test/resources/projects/it1/reference/pom.xml
+++ b/src/test/resources/projects/it1/reference/pom.xml
@@ -2,7 +2,7 @@
 <!--
 
     Sonatype Nexus (TM) Open Source Version
-    Copyright (c) 2018-present Sonatype, Inc.
+    Copyright (c) ${current.year}-present Sonatype, Inc.
     All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
 
     This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,

--- a/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/FooFormat.java
+++ b/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/FooFormat.java
@@ -12,10 +12,10 @@
  */
 package org.sonatype.nexus.repository.foo.internal;
 
-import org.sonatype.nexus.repository.Format;
-
 import javax.inject.Named;
 import javax.inject.Singleton;
+
+import org.sonatype.nexus.repository.Format;
 
 /**
  * Foo repository format.

--- a/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/FooFormat.java
+++ b/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/FooFormat.java
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
@@ -12,10 +12,10 @@
  */
 package org.sonatype.nexus.repository.foo.internal;
 
+import org.sonatype.nexus.repository.Format;
+
 import javax.inject.Named;
 import javax.inject.Singleton;
-
-import org.sonatype.nexus.repository.Format;
 
 /**
  * Foo repository format.

--- a/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/FooRecipeSupport.groovy
+++ b/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/FooRecipeSupport.groovy
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,

--- a/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/security/FooFormatSecurityContributor.java
+++ b/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/security/FooFormatSecurityContributor.java
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
@@ -12,14 +12,13 @@
  */
 package org.sonatype.nexus.repository.foo.internal.security;
 
+import org.sonatype.nexus.repository.Format;
+import org.sonatype.nexus.repository.foo.internal.FooFormat;
+import org.sonatype.nexus.repository.security.RepositoryFormatSecurityContributor;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-
-import org.sonatype.nexus.repository.foo.internal.FooFormat;
-
-import org.sonatype.nexus.repository.Format;
-import org.sonatype.nexus.repository.security.RepositoryFormatSecurityContributor;
 
 /**
  * Foo format security resource.

--- a/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/security/FooFormatSecurityContributor.java
+++ b/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/security/FooFormatSecurityContributor.java
@@ -12,13 +12,14 @@
  */
 package org.sonatype.nexus.repository.foo.internal.security;
 
-import org.sonatype.nexus.repository.Format;
-import org.sonatype.nexus.repository.foo.internal.FooFormat;
-import org.sonatype.nexus.repository.security.RepositoryFormatSecurityContributor;
-
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+
+import org.sonatype.nexus.repository.Format;
+
+import org.sonatype.nexus.repository.foo.internal.FooFormat;
+import org.sonatype.nexus.repository.security.RepositoryFormatSecurityContributor;
 
 /**
  * Foo format security resource.

--- a/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/security/FooFormatSecurityContributor.java
+++ b/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/security/FooFormatSecurityContributor.java
@@ -16,9 +16,9 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.sonatype.nexus.repository.Format;
-
 import org.sonatype.nexus.repository.foo.internal.FooFormat;
+
+import org.sonatype.nexus.repository.Format;
 import org.sonatype.nexus.repository.security.RepositoryFormatSecurityContributor;
 
 /**

--- a/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/security/FooSecurityFacet.java
+++ b/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/security/FooSecurityFacet.java
@@ -12,13 +12,13 @@
  */
 package org.sonatype.nexus.repository.foo.internal.security;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import org.sonatype.nexus.repository.config.Configuration;
 import org.sonatype.nexus.repository.security.ContentPermissionChecker;
 import org.sonatype.nexus.repository.security.SecurityFacetSupport;
 import org.sonatype.nexus.repository.security.VariableResolverAdapter;
-
-import javax.inject.Inject;
-import javax.inject.Named;
 
 /**
  * Foo format security facet.

--- a/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/security/FooSecurityFacet.java
+++ b/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/security/FooSecurityFacet.java
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
@@ -12,13 +12,13 @@
  */
 package org.sonatype.nexus.repository.foo.internal.security;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-
 import org.sonatype.nexus.repository.config.Configuration;
 import org.sonatype.nexus.repository.security.ContentPermissionChecker;
 import org.sonatype.nexus.repository.security.SecurityFacetSupport;
 import org.sonatype.nexus.repository.security.VariableResolverAdapter;
+
+import javax.inject.Inject;
+import javax.inject.Named;
 
 /**
  * Foo format security facet.

--- a/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/ui/UiPluginDescriptorImpl.java
+++ b/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/ui/UiPluginDescriptorImpl.java
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
@@ -12,11 +12,11 @@
  */
 package org.sonatype.nexus.repository.foo.internal.ui;
 
+import org.sonatype.nexus.rapture.UiPluginDescriptorSupport;
+
 import javax.annotation.Priority;
 import javax.inject.Named;
 import javax.inject.Singleton;
-
-import org.sonatype.nexus.rapture.UiPluginDescriptorSupport;
 
 @Named
 @Singleton

--- a/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/ui/UiPluginDescriptorImpl.java
+++ b/src/test/resources/projects/it1/reference/src/main/java/org/sonatype/nexus/repository/foo/internal/ui/UiPluginDescriptorImpl.java
@@ -12,11 +12,11 @@
  */
 package org.sonatype.nexus.repository.foo.internal.ui;
 
-import org.sonatype.nexus.rapture.UiPluginDescriptorSupport;
-
 import javax.annotation.Priority;
 import javax.inject.Named;
 import javax.inject.Singleton;
+
+import org.sonatype.nexus.rapture.UiPluginDescriptorSupport;
 
 @Named
 @Singleton

--- a/src/test/resources/projects/it1/reference/src/main/resources/static/rapture/NX/foo/app/PluginConfig.js
+++ b/src/test/resources/projects/it1/reference/src/main/resources/static/rapture/NX/foo/app/PluginConfig.js
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,

--- a/src/test/resources/projects/it1/reference/src/main/resources/static/rapture/NX/foo/app/PluginStrings.js
+++ b/src/test/resources/projects/it1/reference/src/main/resources/static/rapture/NX/foo/app/PluginStrings.js
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,

--- a/src/test/resources/projects/it1/reference/src/main/resources/static/rapture/NX/foo/util/FooRepositoryUrls.js
+++ b/src/test/resources/projects/it1/reference/src/main/resources/static/rapture/NX/foo/util/FooRepositoryUrls.js
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,

--- a/src/test/resources/projects/it1/reference/src/main/resources/static/rapture/resources/nexus-repository-foo-debug.css
+++ b/src/test/resources/projects/it1/reference/src/main/resources/static/rapture/resources/nexus-repository-foo-debug.css
@@ -1,6 +1,6 @@
 /**
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,

--- a/src/test/resources/projects/it1/reference/src/test/java/org/sonatype/nexus/repository/foo/internal/FooFormatTest.java
+++ b/src/test/resources/projects/it1/reference/src/test/java/org/sonatype/nexus/repository/foo/internal/FooFormatTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,

--- a/src/test/resources/projects/it1/reference/src/test/java/org/sonatype/nexus/repository/foo/internal/security/FooSecurityFacetTest.java
+++ b/src/test/resources/projects/it1/reference/src/test/java/org/sonatype/nexus/repository/foo/internal/security/FooSecurityFacetTest.java
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2018-present Sonatype, Inc.
+ * Copyright (c) ${current.year}-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
@@ -12,6 +12,10 @@
  */
 package org.sonatype.nexus.repository.foo.internal.security;
 
+import org.apache.shiro.authz.AuthorizationException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 import org.sonatype.goodies.testsupport.TestSupport;
 import org.sonatype.nexus.repository.Format;
 import org.sonatype.nexus.repository.Repository;
@@ -19,11 +23,6 @@ import org.sonatype.nexus.repository.http.HttpMethods;
 import org.sonatype.nexus.repository.security.ContentPermissionChecker;
 import org.sonatype.nexus.repository.security.VariableResolverAdapter;
 import org.sonatype.nexus.repository.view.Request;
-
-import org.apache.shiro.authz.AuthorizationException;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
 
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;

--- a/src/test/resources/projects/it1/reference/src/test/java/org/sonatype/nexus/repository/foo/internal/security/FooSecurityFacetTest.java
+++ b/src/test/resources/projects/it1/reference/src/test/java/org/sonatype/nexus/repository/foo/internal/security/FooSecurityFacetTest.java
@@ -12,10 +12,6 @@
  */
 package org.sonatype.nexus.repository.foo.internal.security;
 
-import org.apache.shiro.authz.AuthorizationException;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
 import org.sonatype.goodies.testsupport.TestSupport;
 import org.sonatype.nexus.repository.Format;
 import org.sonatype.nexus.repository.Repository;
@@ -23,6 +19,11 @@ import org.sonatype.nexus.repository.http.HttpMethods;
 import org.sonatype.nexus.repository.security.ContentPermissionChecker;
 import org.sonatype.nexus.repository.security.VariableResolverAdapter;
 import org.sonatype.nexus.repository.view.Request;
+
+import org.apache.shiro.authz.AuthorizationException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;


### PR DESCRIPTION
Generates the current year as the "inceptionYear". 

I could not find a way to make this truly dynamic (e.g. populate the year at runtime of the archetype generation).
For now, it only updates to a new year when we build a new release of the archetype.