### PR TITLE
.gitignore now included for generated formats

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,10 @@
       <testResource>
         <directory>src/test/resources</directory>
         <filtering>true</filtering>
+        <excludes>
+          <!-- Due to workaround to allow copy of hidden .gitignore file, avoid known Mac files from defaultExcludes. -->
+          <exclude>**/.DS_Store</exclude>
+        </excludes>
       </testResource>
     </testResources>
     <pluginManagement>
@@ -138,10 +142,13 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <version>3.1.0</version>
         <configuration>
           <escapeString>\</escapeString>
+          <!-- allow copy of hidden .gitignore file. see: https://maven.apache.org/plugins/maven-resources-plugin/resources-mojo.html#addDefaultExcludes  -->
+          <addDefaultExcludes>false</addDefaultExcludes>
         </configuration>
       </plugin>
       <plugin><!--

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <version>3.1.0</version>
         <configuration>

--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -19,9 +19,6 @@ name="nexus-format-archetype">
     <requiredProperty key="version">
       <defaultValue>0.0.1-SNAPSHOT</defaultValue>
     </requiredProperty>
-    <requiredProperty key="gitignore">
-      <defaultValue>.gitignore</defaultValue>
-    </requiredProperty>
   </requiredProperties>
 
   <fileSets>
@@ -33,7 +30,7 @@ name="nexus-format-archetype">
         <include>Dockerfile</include>
         <include>.circleci/*</include>
         <include>.github/*</include>
-        <include>__gitignore__</include>
+        <include>.gitignore</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -19,6 +19,9 @@ name="nexus-format-archetype">
     <requiredProperty key="version">
       <defaultValue>0.0.1-SNAPSHOT</defaultValue>
     </requiredProperty>
+    <requiredProperty key="gitignore">
+      <defaultValue>.gitignore</defaultValue>
+    </requiredProperty>
   </requiredProperties>
 
   <fileSets>
@@ -30,7 +33,7 @@ name="nexus-format-archetype">
         <include>Dockerfile</include>
         <include>.circleci/*</include>
         <include>.github/*</include>
-        <include>.gitignore</include>
+        <include>__gitignore__</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -30,6 +30,7 @@ name="nexus-format-archetype">
         <include>Dockerfile</include>
         <include>.circleci/*</include>
         <include>.github/*</include>
+        <include>.gitignore</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/src/main/resources/archetype-resources/.gitignore
+++ b/src/main/resources/archetype-resources/.gitignore
@@ -1,0 +1,30 @@
+# Eclipse
+.classpath
+.project
+.settings/
+
+# Maven
+target/
+*.ser
+*.ec
+.mvn/timing.properties
+.mvn/extensions.xml
+.mvn/maven.config
+
+# Intellij
+*.ipr
+*.iml
+*.iws
+.idea/
+
+# OrientDB
+.orientdb_history
+
+# Other
+.DS_Store
+.clover
+*.log
+/*.rc
+atlassian-ide-plugin.xml
+dependency-reduced-pom.xml
+out

--- a/src/test/resources/projects/it1/reference/.gitignore
+++ b/src/test/resources/projects/it1/reference/.gitignore
@@ -1,0 +1,30 @@
+# Eclipse
+.classpath
+.project
+.settings/
+
+# Maven
+target/
+*.ser
+*.ec
+.mvn/timing.properties
+.mvn/extensions.xml
+.mvn/maven.config
+
+# Intellij
+*.ipr
+*.iml
+*.iws
+.idea/
+
+# OrientDB
+.orientdb_history
+
+# Other
+.DS_Store
+.clover
+*.log
+/*.rc
+atlassian-ide-plugin.xml
+dependency-reduced-pom.xml
+out


### PR DESCRIPTION
.gitignore now included for generated formats, changes do not break ITs

This pull request makes the following changes:
* Modifies both the pom.xml and archetype-metadata.xml to allow an initial .gitignore file to be included with generated formats
* Resolves #4 

All hail @bhamail 