### PR TITLE
add download link to maven central

### DIFF
--- a/src/main/resources/archetype-resources/README.md
+++ b/src/main/resources/archetype-resources/README.md
@@ -22,6 +22,7 @@
 
 * [Developing](#developing)
    * [Requirements](#requirements)
+   * [Download](#download)
    * [Building](#building)
 * [Using ${pluginClass} with Nexus Repository Manager 3](#using-${pluginFormat}-with-nexus-repository-manager-3)
 * [Compatibility with Nexus Repository Manager 3 Versions](#compatibility-with-nexus-repository-manager-3-versions)
@@ -47,6 +48,10 @@
 Also, there is a good amount of information available at [Bundle Development](https://help.sonatype.com/display/NXRM3/Bundle+Development).
 
 You may also find it helpful to configure your IDE to use the [Sonatype Code style](https://github.com/sonatype/codestyle).
+
+#[[###]]# Download
+
+ Find pre-compiled files [here](https://search.maven.org/search?q=g:%22org.sonatype.nexus.plugins%22%20AND%20a:%22${rootArtifactId}%22).
 
 #[[###]]# Building
 

--- a/src/test/resources/projects/it1/reference/README.md
+++ b/src/test/resources/projects/it1/reference/README.md
@@ -21,6 +21,7 @@
 
 * [Developing](#developing)
    * [Requirements](#requirements)
+   * [Download](#download)
    * [Building](#building)
 * [Using Foo with Nexus Repository Manager 3](#using-foo-with-nexus-repository-manager-3)
 * [Compatibility with Nexus Repository Manager 3 Versions](#compatibility-with-nexus-repository-manager-3-versions)
@@ -46,6 +47,10 @@
 Also, there is a good amount of information available at [Bundle Development](https://help.sonatype.com/display/NXRM3/Bundle+Development).
 
 You may also find it helpful to configure your IDE to use the [Sonatype Code style](https://github.com/sonatype/codestyle).
+
+### Download
+
+ Find pre-compiled files [here](https://search.maven.org/search?q=g:%22org.sonatype.nexus.plugins%22%20AND%20a:%22nexus-repository-foo%22).
 
 ### Building
 


### PR DESCRIPTION
Add link to download published (pre-compiled) files on central. Taken from [PR #21](https://github.com/sonatype-nexus-community/nexus-repository-apk/pull/21) in [apk](https://github.com/sonatype-nexus-community/nexus-repository-apk) format project. Thanks @LinuxSuRen