### PR TITLE
Avoid leaking older format plugin from distro.

### DIFF
--- a/src/main/resources/archetype-resources/__rootArtifactId__-it/pom.xml
+++ b/src/main/resources/archetype-resources/__rootArtifactId__-it/pom.xml
@@ -89,7 +89,7 @@
       <exclusions>
         <!-- Avoid leaking older format plugin from distro -->
         <exclusion>
-          <groupId>org.sonatype.nexus.plugins</groupId>
+          <groupId>\${groupId}</groupId>
           <artifactId>${rootArtifactId}</artifactId>
         </exclusion>
       </exclusions>

--- a/src/main/resources/archetype-resources/__rootArtifactId__-it/pom.xml
+++ b/src/main/resources/archetype-resources/__rootArtifactId__-it/pom.xml
@@ -86,6 +86,13 @@
       <version>${nxrm-version}</version>
       <type>zip</type>
       <scope>test</scope>
+      <exclusions>
+        <!-- Avoid leaking older format plugin from distro -->
+        <exclusion>
+          <groupId>org.sonatype.nexus.plugins</groupId>
+          <artifactId>${rootArtifactId}</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/src/test/resources/projects/it1/reference/nexus-repository-foo-it/pom.xml
+++ b/src/test/resources/projects/it1/reference/nexus-repository-foo-it/pom.xml
@@ -86,6 +86,13 @@
       <version>${nxrm-version}</version>
       <type>zip</type>
       <scope>test</scope>
+      <exclusions>
+        <!-- Avoid leaking older format plugin from distro -->
+        <exclusion>
+          <groupId>org.sonatype.nexus.plugins</groupId>
+          <artifactId>nexus-repository-foo</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
lifted from [here](https://github.com/sonatype-nexus-community/nexus-repository-r/pull/128/files#diff-2aec029e49623c552b4cec640bc1346bR91).

Should this change be incorporated into the nexus-format-archetype?
