### PR TITLE
Squelching CI build noise

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
   circleci-maven-release-orb: sonatype-nexus-community/circleci-maven-release-orb@0.0.15
 
 build-and-test-commands: &build-and-test-commands
-  mvn-build-test-command: mvn clean verify archetype:integration-test
+  mvn-build-test-command: mvn --batch-mode clean verify archetype:integration-test
   mvn-collect-artifacts-command: |
     mkdir -p ~/project/artifacts/junit/
     # no reporting files to collect from archetype:integration-test goal

--- a/src/main/resources/archetype-resources/.circleci/config.yml
+++ b/src/main/resources/archetype-resources/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
 
 build-and-test-commands: &build-and-test-commands
   executor: nxrm-maven-executor
-  mvn-build-test-command: mvn clean verify -PbuildKar -Dit
+  mvn-build-test-command: mvn --batch-mode clean verify -PbuildKar -Dit
   mvn-collect-artifacts-command: |
     mkdir -p ~/project/artifacts/junit/
     find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/project/artifacts/junit/ \;

--- a/src/test/resources/projects/it1/reference/.circleci/config.yml
+++ b/src/test/resources/projects/it1/reference/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
 
 build-and-test-commands: &build-and-test-commands
   executor: nxrm-maven-executor
-  mvn-build-test-command: mvn clean verify -PbuildKar -Dit
+  mvn-build-test-command: mvn --batch-mode clean verify -PbuildKar -Dit
   mvn-collect-artifacts-command: |
     mkdir -p ~/project/artifacts/junit/
     find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/project/artifacts/junit/ \;


### PR DESCRIPTION
Disable download progress bar progress logs when builds on Circle CI. 

See https://github.com/sonatype-nexus-community/nexus-repository-apk/pull/26#discussion_r500511692