### PR TITLE
use rso-public-grid to fetch nexus repository manager SNAPSHOT artifacts

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -52,10 +52,10 @@
   </properties>
 
   <repositories>
-    <!-- ensure we can find the parent pom when starting from an empty local .m2 repository -->
+    <!-- ensure we can find a SNAPSHOT parent pom when starting from an empty local .m2 repository -->
     <repository>
-      <id>rso-snapshots</id>
-      <url>https://repository.sonatype.org/content/repositories/snapshots</url>
+      <id>rso-public-grid</id>
+      <url>https://repository.sonatype.org/content/groups/sonatype-public-grid/</url>
     </repository>
   </repositories>
 

--- a/src/test/resources/projects/it1/reference/pom.xml
+++ b/src/test/resources/projects/it1/reference/pom.xml
@@ -50,10 +50,10 @@
   </properties>
 
   <repositories>
-    <!-- ensure we can find the parent pom when starting from an empty local .m2 repository -->
+    <!-- ensure we can find a SNAPSHOT parent pom when starting from an empty local .m2 repository -->
     <repository>
-      <id>rso-snapshots</id>
-      <url>https://repository.sonatype.org/content/repositories/snapshots</url>
+      <id>rso-public-grid</id>
+      <url>https://repository.sonatype.org/content/groups/sonatype-public-grid/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
Change to use the "group" repo: `sonatype-public-grid`, which includes SNAPSHOT versions of Nexus Repository Manager. This is needed when a format plugin must depend on a SNAPSHOT ("un-released") version of Nexus.

That said, ideally, it would be nice to avoid any use of the `<repositories>` tag in the plugin pom.xml. Unfortunately, I can't figure out a nicer way to both support the use of Nexus SNAPSHOT versions, while also keeping the archetype simple, and avoiding the need to edit a maven settings.xml file.

I looked into some hoops involving a maven profile (like that below) to only activate the `<repositories>` tag when the plugin version depends on a SNAPSHOT version of Nexus, but couldn't find a non-convoluted solution. It is a "Chicken and Egg" issue - you gotta be able to download the parent pom before much of anything else can happen.

```
...
      <plugin>
        <groupId>org.codehaus.mojo</groupId>
        <artifactId>build-helper-maven-plugin</artifactId>
        <version>3.0.0</version>
        <executions>
          <execution>
            <!-- sets the only.when.is.snapshot.used property to true if SNAPSHOT was used,
                to the project version otherwise -->
            <id>build-helper-regex-is-snapshot-used</id>
            <phase>validate</phase>
            <goals>
              <goal>regex-property</goal>
            </goals>
            <configuration>
              <name>isParentSnapshot</name>
              <value>${project.parent.version}</value>
              <regex>.*-SNAPSHOT</regex>
              <replacement>true</replacement>
              <failIfNoMatch>false</failIfNoMatch>
            </configuration>
          </execution>
        </executions>
      </plugin>

...

    <profile>
      <id>isSnapshot</id>
      <activation>
        <property>
          <name>isParentSnapshot</name>
          <value>true</value>
        </property>
      </activation>

      <repositories>
        <!-- ensure we can find a SNAPSHOT parent pom when starting from an empty local .m2 repository -->
        <repository>
          <id>rso-public-grid</id>
          <url>https://repository.sonatype.org/content/groups/sonatype-public-grid/</url>
        </repository>
      </repositories>

    </profile>
```

Therefore I'm leaning towards keeping the current (non-best practice) solution of including a `<repositories>` tag to the  repo serving SNAPSHOTs in the pom.ml.

Happy to find a better way!